### PR TITLE
Fix version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "~4.2.0"
+        "cakephp/cakephp": "^4.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.3"


### PR DESCRIPTION
Using ~ and only allowing 4.2, and not 4.3+ seems counterproductive, as in minors this should also be future compatible.

Your test harness should check both min/max - see my plugins on how to do that.